### PR TITLE
퀴즈 상세 페이지 취소 버튼 클릭시 이전 url 로 이동하도록 수정

### DIFF
--- a/src/main/resources/templates/html/quiz/quiz-view.html
+++ b/src/main/resources/templates/html/quiz/quiz-view.html
@@ -34,21 +34,35 @@
                     </li>
                 </ul>
             </div>
-            <form th:action="@{/quiz/{quizNum}/{quizId}(quizNum=${quizNum}, quizId=${quizId})}" th:object="${requestDTO}" method="post">
-                <fieldset th:attr="disabled=${isDisabled} ? 'disabled' : null">
-                    <div class="answer-wrap">
+            <form th:action="@{/quiz/{quizNum}/{quizId}(quizNum=${quizNum}, quizId=${quizId})}"
+                  th:object="${requestDTO}" method="post">
+                <div class="answer-wrap">
+                    <fieldset th:attr="disabled=${isDisabled} ? 'disabled' : null">
                         <label for="answer">답변등록</label>
                         <textarea id="answer" name="quizAnswer" th:field="*{quizAnswer}"></textarea>
-                        <div class="btn-wrap type2 mg-t--20">
-                            <button type="button" class="btn btn-half btn-line">
-                                취소
-                            </button>
+                    </fieldset>
+                    <div class="btn-wrap type2 mg-t--20">
+                        <button id="goBackButton" type="button" class="btn btn-half btn-line">
+                            취소
+                        </button>
+                        <script>
+                            document.getElementById('goBackButton').addEventListener('click', function() {
+                                const previousURL = document.referrer;
+                                if (previousURL) {
+                                    window.location.href = previousURL;
+                                } else {
+                                    // 이전 페이지 정보가 없는 경우 기본적으로 이동할 URL을 설정
+                                    window.location.href = '/';
+                                }
+                            });
+                        </script>
+                        <fieldset th:attr="disabled=${isDisabled} ? 'disabled' : null">
                             <button type="submit" class="btn btn-half btn-pink">
                                 등록
                             </button>
-                        </div>
+                        </fieldset>
                     </div>
-                </fieldset>
+                </div>
             </form>
         </div>
     </section>


### PR DESCRIPTION
현재 퀴즈 상세 페이지에서 뒤로가는 기능이 없고, 취소 버튼은 아무런 역할을 하지 않아 취소 버튼에 뒤로가기 기능 할당